### PR TITLE
Added platform specific command calls.

### DIFF
--- a/src/dash.ts
+++ b/src/dash.ts
@@ -1,3 +1,5 @@
+import {platform} from 'os';
+
 export class Dash {
 
     /**
@@ -16,7 +18,7 @@ export class Dash {
             uri += '&keys=' + keys;
         }
 
-        return 'open -g "' + uri + '"';
+        return `${this.getPlatformCommand()} "${uri}"`;
     }
 
     /**
@@ -32,5 +34,30 @@ export class Dash {
         }
 
         return '';
+    }
+
+    /**
+     * Get platform specific command to run/execute query on Dash, Zeal or Velocity
+     *
+     * @return {string} the command that will be run to 
+     */
+    getPlatformCommand() {
+        // Inspired by the Dash plugin for Atom
+        // (see https://github.com/blakeembrey/atom-dash/blob/master/lib/dash.coffee)
+        let command = '';
+        switch (platform().toLowerCase()) {
+            case 'win32':
+                command = 'cmd /c start ""';
+                break;
+            case 'linux':
+            case 'freebsd':
+            case 'sunos':
+                command = 'xdg-open';
+                break;
+            case 'darwin':
+            default:
+                command = 'open -g';
+        }
+        return command;
     }
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,21 +1,43 @@
 
 import * as assert from 'assert';
 import {Dash} from '../src/dash';
+import {platform} from 'os';
+import * as proxyquire from 'proxyquire';
+
+var platforms = {
+    'win32': 'cmd /c start ""',
+    'linux': 'xdg-open',
+    'freebsd': 'xdg-open',
+    'sunos': 'xdg-open',
+    'darwin': 'open -g',
+    'unknown': 'open -g',
+}
 
 suite("Dash Tests", () => {
 
     test('Get command with keys', () => {
         let dash = new Dash();
-        var uri = dash.getCommand('size', ['css','less']);
+        var uri = dash.getCommand('size', ['css', 'less']);
+        var command = platforms[platform()] || 'open -g';
 
-        assert.equal(uri, 'open -g "dash-plugin://query=size&keys=css,less"');
+        assert.equal(uri, `${command} "dash-plugin://query=size&keys=css,less"`);
     });
 
     test('Get command with no keys', () => {
         let dash = new Dash();
         var uri = dash.getCommand('size');
+        var command = platforms[platform()] || 'open -g';
 
-        assert.equal(uri, 'open -g "dash-plugin://query=size"');
+        assert.equal(uri, `${command} "dash-plugin://query=size"`);
+    });
+
+    test('Get platform command line ', () => {
+
+        let dash = new Dash();
+        let command = dash.getPlatformCommand();
+
+        let expectedCommand = platforms[platform()] || 'open -g';
+        assert.equal(command, expectedCommand);
     });
 
     test('Get keys with exist docset', () => {


### PR DESCRIPTION
Works fine on Windows. Haven't checked on OS X or Linux. Default return is the OS X command.

Added test, but can't find a way to mock the call to os.platform for it to return something else no matter the platform....