### PR TITLE
Added Zeal support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "type": "object",
       "title": "Dash Configuration",
       "properties": {
+        "dash.zeal": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specify if you're using Zeal because it handles the Dash URI differently."
+        },
         "dash.docset.css": {
           "type": "array",
           "items": {

--- a/package.json
+++ b/package.json
@@ -58,11 +58,6 @@
       "type": "object",
       "title": "Dash Configuration",
       "properties": {
-        "dash.zeal": {
-          "type": "boolean",
-          "default": false,
-          "description": "Specify if you're using Zeal because it handles the Dash URI differently."
-        },
         "dash.docset.css": {
           "type": "array",
           "items": {

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -1,15 +1,14 @@
-import {platform} from 'os';
-import {exec} from 'child_process';
 export class Dash {
 
     /**
      * Get command to open dash
      *
      * @param {string} query - text to find
+     * @param {string} OS - string representing the OS
      * @param {string} docsets - array of docset e.g. [css, less]
-     * @return {string} dash uri
+     * @return {string} dash handler and uri
      */
-    getCommand(query: string, docsets: Array<string> = []): string {
+    getCommand(query: string, OS: string, docsets: Array<string> = []): string {
 
         var uri = 'dash-plugin://query=' + encodeURIComponent(query);
         var keys = this.getKeys(docsets);
@@ -18,7 +17,7 @@ export class Dash {
             uri += '&keys=' + keys;
         }
 
-        return this.getDashURIHandler() + ' ' + this.getOSSpecificURI(uri);
+        return this.getDashURIHandler(OS) + ' ' + this.getOSSpecificURI(uri, OS);
     }
 
     /**
@@ -39,9 +38,10 @@ export class Dash {
     /**
      * Returns the command to handle the URI in the command line.
      *
+     * @param {string} OS - string representing the OS
      * @return {string} name and flags of the command that takes the URI as an argument
      */
-    getDashURIHandler(): String {
+    getDashURIHandler(OS: string): string {
         // hacky switch statement
         return {
             'darwin': 'open -g',
@@ -49,19 +49,20 @@ export class Dash {
             // start Zeal before we pass it a URI so it works whether Zeal is running in background or not.
             // Why is this needed? I have no idea, but I think Qt has to start up a listener on cmd before it will work.
             'win32': 'start dash-plugin:// && start'
-        }[platform()] || 'zeal';
+        }[OS] || 'zeal';
     }
 
     /**
      * Returns the OS specific URI to be handled.
      *
      * @param {string} uri - original constructed URI
+     * @param {string} OS - string representing the OS
      * @return {string} OS-specific URI to pass to handler, mainly because of Windows
      */
-    getOSSpecificURI(uri: String): String {
+    getOSSpecificURI(uri: string, OS: string): string {
         return {
             // on Windows, start can't deal with the double quotes, and & needs to be escaped with ^
             'win32': uri.replace('&', '^&')
-        }[platform()] || '"' + uri + '"';
+        }[OS] || '"' + uri + '"';
     }
 }

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -1,3 +1,4 @@
+import { workspace, WorkspaceConfiguration } from 'vscode';
 export class Dash {
 
     /**
@@ -16,6 +17,10 @@ export class Dash {
             uri += '&keys=' + keys;
         }
 
+        if (this.usingZeal()) {
+            return 'zeal "' + uri + '"';
+        }
+
         return 'open -g "' + uri + '"';
     }
 
@@ -32,5 +37,14 @@ export class Dash {
         }
 
         return '';
+    }
+
+    /**
+     * Check if dash.zeal is set
+     *
+     * @return {WorkspaceConfiguration} if dash.zeal
+     */
+    usingZeal(): WorkspaceConfiguration {
+        return workspace.getConfiguration("dash.zeal");
     }
 }

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -1,14 +1,26 @@
 export class Dash {
+    private OS: string;
+    private URIHandler: string;
+
+    constructor(OS: string) {
+        this.OS = OS;
+        this.URIHandler = {
+            'darwin': 'open -g',
+            'linux': 'zeal',
+            // start Zeal before we pass it a URI so it works whether Zeal is running in background or not.
+            // Why is this needed? I have no idea, but I think Qt has to start up a listener on cmd before it will work.
+            'win32': 'start dash-plugin:// && start'
+        }[this.OS] || 'zeal';
+    }
 
     /**
      * Get command to open dash
      *
      * @param {string} query - text to find
-     * @param {string} OS - string representing the OS
      * @param {string} docsets - array of docset e.g. [css, less]
      * @return {string} dash handler and uri
      */
-    getCommand(query: string, OS: string, docsets: Array<string> = []): string {
+    getCommand(query: string, docsets: Array<string> = []): string {
 
         var uri = 'dash-plugin://query=' + encodeURIComponent(query);
         var keys = this.getKeys(docsets);
@@ -17,7 +29,7 @@ export class Dash {
             uri += '&keys=' + keys;
         }
 
-        return this.getDashURIHandler(OS) + ' ' + this.getOSSpecificURI(uri, OS);
+        return this.URIHandler + ' ' + this.getOSSpecificURI(uri);
     }
 
     /**
@@ -36,33 +48,15 @@ export class Dash {
     }
 
     /**
-     * Returns the command to handle the URI in the command line.
-     *
-     * @param {string} OS - string representing the OS
-     * @return {string} name and flags of the command that takes the URI as an argument
-     */
-    getDashURIHandler(OS: string): string {
-        // hacky switch statement
-        return {
-            'darwin': 'open -g',
-            'linux': 'zeal',
-            // start Zeal before we pass it a URI so it works whether Zeal is running in background or not.
-            // Why is this needed? I have no idea, but I think Qt has to start up a listener on cmd before it will work.
-            'win32': 'start dash-plugin:// && start'
-        }[OS] || 'zeal';
-    }
-
-    /**
      * Returns the OS specific URI to be handled.
      *
      * @param {string} uri - original constructed URI
-     * @param {string} OS - string representing the OS
      * @return {string} OS-specific URI to pass to handler, mainly because of Windows
      */
-    getOSSpecificURI(uri: string, OS: string): string {
+    getOSSpecificURI(uri: string): string {
         return {
             // on Windows, start can't deal with the double quotes, and & needs to be escaped with ^
             'win32': uri.replace('&', '^&')
-        }[OS] || '"' + uri + '"';
+        }[this.OS] || '"' + uri + '"';
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import {exec} from 'child_process';
 import {Dash} from './dash';
 import {platform} from 'os';
 
+const OS: string = platform();
+
 export function activate(context: ExtensionContext) {
 
 	context.subscriptions.push(commands.registerCommand('extension.dash.specific', () => {
@@ -23,10 +25,9 @@ function searchSpecific() {
     var languageId = editor.document.languageId;
     var docsets = getDocsets(languageId);
 
-    var dash = new Dash();
-    var OS = platform();
+    var dash = new Dash(OS);
 
-    exec(dash.getCommand(query, OS, docsets));
+    exec(dash.getCommand(query, docsets));
 }
 
 /**
@@ -36,10 +37,9 @@ function searchAll() {
     var editor = getEditor();
     var query = getSelectedText(editor);
 
-    var dash = new Dash();
-    var OS = platform();
+    var dash = new Dash(OS);
 
-    exec(dash.getCommand(query, OS));
+    exec(dash.getCommand(query));
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ function searchSpecific() {
     var docsets = getDocsets(languageId);
 
     var dash = new Dash();
-    handleZeal(dash);
+
     exec(dash.getCommand(query, docsets));
 }
 
@@ -35,7 +35,7 @@ function searchAll() {
     var query = getSelectedText(editor);
 
     var dash = new Dash();
-    handleZeal(dash);
+
     exec(dash.getCommand(query));
 }
 
@@ -85,17 +85,4 @@ function getDocsets(languageId: string): Array<string> {
     }
 
     return [];
-}
-
-/**
- * Handle weird Zeal bug where it does not start up correctly
- *
- * @param {Dash} dash dash object
- * @return {void}
- */
-function handleZeal(dash: Dash): void {
-    if (dash.usingZeal()) {
-        exec('zeal');
-        // not sure why but the other command does not open zeal correctly sometimes, there's an error in Qt
-    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ function searchSpecific() {
     var docsets = getDocsets(languageId);
 
     var dash = new Dash();
-
+    handleZeal(dash);
     exec(dash.getCommand(query, docsets));
 }
 
@@ -35,6 +35,7 @@ function searchAll() {
     var query = getSelectedText(editor);
 
     var dash = new Dash();
+    handleZeal(dash);
     exec(dash.getCommand(query));
 }
 
@@ -84,4 +85,17 @@ function getDocsets(languageId: string): Array<string> {
     }
 
     return [];
+}
+
+/**
+ * Handle weird Zeal bug where it does not start up correctly
+ *
+ * @param {Dash} dash dash object
+ * @return {void}
+ */
+function handleZeal(dash: Dash): void {
+    if (dash.usingZeal()) {
+        exec('zeal');
+        // not sure why but the other command does not open zeal correctly sometimes, there's an error in Qt
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import {window, workspace, commands, ExtensionContext, TextEditor, Selection} from 'vscode';
 import {exec} from 'child_process';
 import {Dash} from './dash';
+import {platform} from 'os';
 
 export function activate(context: ExtensionContext) {
 
@@ -23,8 +24,9 @@ function searchSpecific() {
     var docsets = getDocsets(languageId);
 
     var dash = new Dash();
+    var OS = platform();
 
-    exec(dash.getCommand(query, docsets));
+    exec(dash.getCommand(query, OS, docsets));
 }
 
 /**
@@ -35,8 +37,9 @@ function searchAll() {
     var query = getSelectedText(editor);
 
     var dash = new Dash();
+    var OS = platform();
 
-    exec(dash.getCommand(query));
+    exec(dash.getCommand(query, OS));
 }
 
 /**

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,56 +5,56 @@ import {Dash} from '../src/dash';
 suite("Dash Tests", () => {
 
     test('Get command with keys for macOS', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'darwin', ['css','less']);
+        let dash = new Dash('darwin');
+        var uri = dash.getCommand('size', ['css','less']);
 
         assert.equal(uri, 'open -g "dash-plugin://query=size&keys=css,less"');
     });
 
     test('Get command with no keys for macOS', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'darwin');
+        let dash = new Dash('darwin');
+        var uri = dash.getCommand('size');
 
         assert.equal(uri, 'open -g "dash-plugin://query=size"');
     });
 
     test('Get command with keys for Windows', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'win32', ['css','less']);
+        let dash = new Dash('win32');
+        var uri = dash.getCommand('size', ['css','less']);
 
         assert.equal(uri, 'start dash-plugin:// && start dash-plugin://query=size^&keys=css,less');
     });
 
     test('Get command with no keys for Windows', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'win32');
+        let dash = new Dash('win32');
+        var uri = dash.getCommand('size');
 
         assert.equal(uri, 'start dash-plugin:// && start dash-plugin://query=size');
     });
 
     test('Get command with keys for Linux', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'linux', ['css','less']);
+        let dash = new Dash('linux');
+        var uri = dash.getCommand('size', ['css','less']);
 
         assert.equal(uri, 'zeal "dash-plugin://query=size&keys=css,less"');
     });
 
     test('Get command with no keys for Linux', () => {
-        let dash = new Dash();
-        var uri = dash.getCommand('size', 'linux');
+        let dash = new Dash('linux');
+        var uri = dash.getCommand('size');
 
         assert.equal(uri, 'zeal "dash-plugin://query=size"');
     });
 
     test('Get keys with exist docset', () => {
-        let dash = new Dash();
+        let dash = new Dash('darwin');
         var keys = dash.getKeys(['css', 'less']);
 
         assert.equal(keys, 'css,less');
     });
 
     test('Get keys with empty docset', () => {
-        let dash = new Dash();
+        let dash = new Dash('darwin');
         var keys = dash.getKeys([]);
 
         assert.equal(keys, '');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -4,18 +4,46 @@ import {Dash} from '../src/dash';
 
 suite("Dash Tests", () => {
 
-    test('Get command with keys', () => {
+    test('Get command with keys for macOS', () => {
         let dash = new Dash();
-        var uri = dash.getCommand('size', ['css','less']);
+        var uri = dash.getCommand('size', 'darwin', ['css','less']);
 
         assert.equal(uri, 'open -g "dash-plugin://query=size&keys=css,less"');
     });
 
-    test('Get command with no keys', () => {
+    test('Get command with no keys for macOS', () => {
         let dash = new Dash();
-        var uri = dash.getCommand('size');
+        var uri = dash.getCommand('size', 'darwin');
 
         assert.equal(uri, 'open -g "dash-plugin://query=size"');
+    });
+
+    test('Get command with keys for Windows', () => {
+        let dash = new Dash();
+        var uri = dash.getCommand('size', 'win32', ['css','less']);
+
+        assert.equal(uri, 'start dash-plugin:// && start dash-plugin://query=size^&keys=css,less');
+    });
+
+    test('Get command with no keys for Windows', () => {
+        let dash = new Dash();
+        var uri = dash.getCommand('size', 'win32');
+
+        assert.equal(uri, 'start dash-plugin:// && start dash-plugin://query=size');
+    });
+
+    test('Get command with keys for Linux', () => {
+        let dash = new Dash();
+        var uri = dash.getCommand('size', 'linux', ['css','less']);
+
+        assert.equal(uri, 'zeal "dash-plugin://query=size&keys=css,less"');
+    });
+
+    test('Get command with no keys for Linux', () => {
+        let dash = new Dash();
+        var uri = dash.getCommand('size', 'linux');
+
+        assert.equal(uri, 'zeal "dash-plugin://query=size"');
     });
 
     test('Get keys with exist docset', () => {


### PR DESCRIPTION
Zeal handles the Dash URI differently, at least on Windows. Instead of
"open -g <URI>" it has to call "zeal <URI>". Which also doesn't work
sometimes for some reason or other.

I've only tested this on a Windows 10 machine, will do more testing this week on a VM for Linux and Windows if I can find a copy. Can anyone confirm if the lack of support was just a Windows thing? 