### PR TITLE
change mistake  title infomation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       },
       {
         "command": "extension.dash.emptySyntax",
-        "title": "Search in Dash for current language documentation"
+        "title": "Open Dash for current language documentation"
       },
       {
         "command": "extension.dash.customSyntax",


### PR DESCRIPTION
command:extension.dash.emptySyntax,has mistake title description. 
changed it.
