### PR TITLE
version bump, custom docsets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
   - 'npm install -g typescript@2.5.3'
   - 'npm install'
 script:
-  - 'tsc && node ./node_modules/vscode/bin/compile'
+  - 'tsc && node ./node_modules/vscode/bin/install'
   - 'npm test'
 after_script: 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^0.10.1"
+    "vscode": "^1.22.0"
   },
   "bugs": {
     "url": "https://github.com/deerawan/vscode-dash/issues",
@@ -80,6 +80,17 @@
       "type": "object",
       "title": "Dash Configuration",
       "properties": {
+        "dash.custom_docsets": {
+          "type": "object",
+          "items": {
+            "type": "array"
+          },
+          "default": {}
+        },
+        "dash.custom_docsets_warning": {
+          "type": "boolean",
+          "default": true
+        },
         "dash.docset.ansible": {
           "type": "array",
           "items": {
@@ -630,14 +641,15 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "vscode:prepublish": "node ./node_modules/typescript/bin/tsc -p ./",
+    "compile": "node ./node_modules/typescript/bin/tsc -watch -p ./",
     "contributor:add": "all-contributors add",
     "contributor:generate": "all-contributors generate",
     "contributor:check": "all-contributors check",
     "test": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec --ui tdd ./out/test/extension.test.js",
     "test-local": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec --ui tdd ./out/test/extension.test.js",
     "precommit": "lint-staged",
+    "postinstall": "node ./node_modules/vscode/bin/install",
     "format": "prettier --write \"{src,test}/**/*.ts\"",
     "lint": "tslint -c tslint.json 'src/**/*.ts' 'test/**/*.ts' --fix"
   },
@@ -652,7 +664,9 @@
     "tslint": "^5.7.0",
     "tslint-config-prettier": "^1.6.0",
     "typescript": "^2.5.3",
-    "vscode": "0.10.x"
+    "vscode": "1.1.18",
+    "@types/node": "^6.0.40",
+    "@types/mocha": "^2.2.32"
   },
   "lint-staged": {
     "*.{ts,json}": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
   TextEditor,
   Selection,
   InputBoxOptions,
+  ConfigurationTarget,
 } from 'vscode';
 import { exec } from 'child_process';
 import { Dash } from './dash';
@@ -138,10 +139,30 @@ function getSelectedText(editor: TextEditor) {
  * @return {Array<string>}
  */
 function getDocsets(languageId: string): Array<string> {
-  const config = workspace.getConfiguration('dash.docset');
+  const config = workspace.getConfiguration('dash');
 
-  if (config[languageId]) {
-    return config[languageId];
+  const customLang = config.get('custom_docsets')[languageId];
+  if (customLang) {
+    if (typeof (customLang) === 'string')
+      return [customLang];
+    else if (customLang instanceof Array)
+      return customLang;
+  }
+
+  const docsets = config.get('docset');
+
+  if (docsets[languageId]) {
+    return docsets[languageId];
+  }
+
+  const showWarning = config.get('custom_docsets_warning');
+
+  if (showWarning) {
+    window.showInformationMessage(
+      `Unknown language id. You may add '${languageId}' to dash.custom_docsets setting`,
+      'Never show again').then((s) => {
+        config.update('custom_docsets_warning', false, ConfigurationTarget.Global);
+      });
   }
 
   return [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"module": "commonjs",
 		"target": "ES5",
 		"outDir": "out",
-		"noLib": true,
+		"noLib": false,
 		"sourceMap": true
 	},
 	"exclude": [

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,1 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />
+/// <reference path="../node_modules/vscode/vscode.d.ts" />


### PR DESCRIPTION
fixes #25 

I've added this settings for test:
```
"dash.custom_docsets": {
        "gdscript" : ["godot"],
        "cmake": "cmake"
    }
```

Maybe we should switch from language id to file extensions, don't know