### PR TITLE
set extension kind as ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "2.1.0",
   "publisher": "deerawan",
   "icon": "images/dash.png",
+  "extensionKind": "ui",
   "galleryBanner": {
     "color": "#7171AD",
     "theme": "dark"


### PR DESCRIPTION
To avoid the extension to be run on workspace / remote machine, set the extension kind of vscode-dash as `ui` based on documentation https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location

closes #50 