### PR TITLE
Added support for Arduino

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -110,6 +110,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "akdir",
+      "name": "akdir",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/19649463?v=4",
+      "profile": "https://github.com/akdir",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Ansible | ansible | dash.languageIdToDocsetMap.ansible, dash.languageIdToDocsetM
 C++ | cpp,net,boost,qt,cvcpp,cocos2dx,c,manpages | dash.languageIdToDocsetMap.cpp | [link](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 C# | net,mono,unity3d | dash.languageIdToDocsetMap.csharp
 Clojure | clojure | dash.languageIdToDocsetMap.clojure
-Cmake | cmake | dash.languageIdToDocsetMap.cmake | [link](https://marketplace.visualstudio.com/items?itemName=twxs.cmake)
 CoffeeScript | coffee | dash.languageIdToDocsetMap.coffee
 CSS | css,bootstrap,foundation,less,awesome,<br>cordova,phonegap | dash.languageIdToDocsetMap.css
 Dart | dartlang,polymerdart,angulardart | dash.languageIdToDocsetMap.dart | [link](https://marketplace.visualstudio.com/items?itemName=DanTup.dart-code)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ first in order to allow VS Code to detect the language.
 Language | Dash Docset Keys | Docset Setting | Language Plugin |
 ------------ | ------------- | ------------- | :-------------: |
 Ansible | ansible | dash.languageIdToDocsetMap.ansible, dash.languageIdToDocsetMap.ansible-advanced | [link](https://marketplace.visualstudio.com/items?itemName=haaaad.ansible)
-Arduino | arduino | dash.languageIdToDocsetMap.arduino | [link](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-arduino)
 C++ | cpp,net,boost,qt,cvcpp,cocos2dx,c,manpages | dash.languageIdToDocsetMap.cpp | [link](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 C# | net,mono,unity3d | dash.languageIdToDocsetMap.csharp
 Clojure | clojure | dash.languageIdToDocsetMap.clojure
@@ -107,6 +106,7 @@ File Name | Dash Docset Keys | Docset Setting
 vagrantfile | vagrant | dash.fileNameToDocsetMap["vagrantfile"]
 gruntfile.js | grunt | dash.fileNameToDocsetMap["gruntfile.js"]
 gulpfile.js | gulp | dash.fileNameToDocsetMap["gulpfile.js"]
+*.ino | arduino | dash.fileNameToDocsetMap["*.ino"]
 
 ### What is `Dash Docset Keys`?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Also support [Zeal](https://zealdocs.org/) and [Velocity](https://velocity.silverlakesoftware.com/).
 
 [![Build Status](https://travis-ci.org/deerawan/vscode-dash.svg?branch=master)](https://travis-ci.org/deerawan/vscode-dash) [![Coverage Status](https://coveralls.io/repos/deerawan/vscode-dash/badge.svg?branch=master&service=github)](https://coveralls.io/github/deerawan/vscode-dash?branch=master)
-[![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors-)
 
 ![vscode dash](https://raw.githubusercontent.com/deerawan/vscode-dash/master/images/vscode-dash.gif)
 
@@ -43,6 +43,7 @@ first in order to allow VS Code to detect the language.
 Language | Dash Docset Keys | Docset Setting | Language Plugin |
 ------------ | ------------- | ------------- | :-------------: |
 Ansible | ansible | dash.languageIdToDocsetMap.ansible, dash.languageIdToDocsetMap.ansible-advanced | [link](https://marketplace.visualstudio.com/items?itemName=haaaad.ansible)
+Arduino | arduino | dash.languageIdToDocsetMap.arduino | [link](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-arduino)
 C++ | cpp,net,boost,qt,cvcpp,cocos2dx,c,manpages | dash.languageIdToDocsetMap.cpp | [link](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 C# | net,mono,unity3d | dash.languageIdToDocsetMap.csharp
 Clojure | clojure | dash.languageIdToDocsetMap.clojure
@@ -175,6 +176,7 @@ Thank you for these awesome contributors
     <td align="center"><a href="https://www.upwork.com/fl/cuylerstuwe"><img src="https://avatars0.githubusercontent.com/u/20496944?v=4" width="100px;" alt="Cuyler Stuwe"/><br /><sub><b>Cuyler Stuwe</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=salembeats" title="Code">💻</a></td>
     <td align="center"><a href="https://ozylog.com"><img src="https://avatars3.githubusercontent.com/u/534150?v=4" width="100px;" alt="Cahya Pribadi"/><br /><sub><b>Cahya Pribadi</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=ozylog" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/markokajzer"><img src="https://avatars3.githubusercontent.com/u/9379317?v=4" width="100px;" alt="Marko Kajzer"/><br /><sub><b>Marko Kajzer</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=markokajzer" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/akdir"><img src="https://avatars0.githubusercontent.com/u/19649463?v=4" width="100px;" alt="akdir"/><br /><sub><b>akdir</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=akdir" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Arduino | arduino | dash.languageIdToDocsetMap.arduino | [link](https://marketpl
 C++ | cpp,net,boost,qt,cvcpp,cocos2dx,c,manpages | dash.languageIdToDocsetMap.cpp | [link](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 C# | net,mono,unity3d | dash.languageIdToDocsetMap.csharp
 Clojure | clojure | dash.languageIdToDocsetMap.clojure
+Cmake | cmake | dash.languageIdToDocsetMap.cmake | [link](https://marketplace.visualstudio.com/items?itemName=twxs.cmake)
 CoffeeScript | coffee | dash.languageIdToDocsetMap.coffee
 CSS | css,bootstrap,foundation,less,awesome,<br>cordova,phonegap | dash.languageIdToDocsetMap.css
 Dart | dartlang,polymerdart,angulardart | dash.languageIdToDocsetMap.dart | [link](https://marketplace.visualstudio.com/items?itemName=DanTup.dart-code)

--- a/package.json
+++ b/package.json
@@ -104,9 +104,6 @@
             "clojure": [
               "clojure"
             ],
-            "cmake": [
-              "cmake"
-            ],
             "coffee": [
               "coffee"
             ],

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
             "clojure": [
               "clojure"
             ],
+            "cmake": [
+              "cmake"
+            ],
             "coffee": [
               "coffee"
             ],

--- a/package.json
+++ b/package.json
@@ -395,6 +395,9 @@
             ],
             "gulpfile.js": [
               "gulp"
+            ],
+            "*.ino": [
+              "arduino"
             ]
           }
         },
@@ -428,7 +431,7 @@
     "@types/vscode": "^1.37.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "all-contributors-cli": "^6.9.1",
+    "all-contributors-cli": "^6.9.3",
     "coveralls": "^3.0.6",
     "eslint": "^6.1.0",
     "husky": "^3.0.3",


### PR DESCRIPTION
### Changelog

I added support for Arduino by detecting the fileName using dash.fileNameToDocsetMap. This is because VSCode sees arduino(*.ino) files as *.cpp files. The output of `vscode.window.activeEditor.document.languageId` is cpp for arduino(*.ino) files. To mitigate this problem we map `*.ino` files with dash.fileNameToDocsetMap to arduino. Dash and Zeal still show us dash docsets of cpp, but the arduino docsets come first, because we prioritize docset matching by file name before languageId.

### Checklist

- [x] Code compiles correctly
- [ ] Add or update tests, if possible
- [x] All tests passing
- [x] Update the README, if necessary
- [x] New contributor? added myself via `npm run contributor:add`
