### PR TITLE
Added support for latex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Java | java,javafx,grails,groovy,playjava,spring,<br>cvj,processing | dash.langu
 JavaScript | javascript,jquery,jqueryui,jquerym,react,<br>angularjs,backbone,marionette,meteor,<br>sproutcore,moo,prototype,bootstrap,<br>foundation,lodash,underscore,ember,<br>sencha,extjs,titanium,knockout,zepto,<br>yui,d3,svg,dojo,coffee,nodejs,express,<br>grunt,mongoose,moment,require,<br>awsjs,jasmine,sails,sinon,chai,<br>html,css,cordova,phonegap,unity3d | dash.languageIdToDocsetMap.javascript
 Julia | julia | dash.languageIdToDocsetMap.julia | [link](https://marketplace.visualstudio.com/items?itemName=julialang.language-julia)
 Kotlin | androidktx,kotlin | dash.languageIdToDocsetMap.kotlin | [link](https://marketplace.visualstudio.com/items?itemName=mathiasfrohlich.Kotlin)
+Latex | latex | dash.languageIdToDocsetMap.latex | [link](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)
 Less | less | dash.languageIdToDocsetMap.less
 Lua | lua,corona | dash.languageIdToDocsetMap.lua | [link](https://marketplace.visualstudio.com/items?itemName=gccfeli.vscode-lua)
 Markdown | markdown | dash.languageIdToDocsetMap.markdown

--- a/package.json
+++ b/package.json
@@ -246,6 +246,9 @@
               "androidktx",
               "kotlin"
             ],
+            "latex": [
+              "latex"
+            ],
             "less": [
               "less"
             ],


### PR DESCRIPTION
### Changelog

Added support for latex. If you want to search for document, you have to not forget to select or write the `\` of the latex function, or enable Fuzzy Searching in Dash or Zeal(which is still in beta). 

### Checklist

- [x] Code compiles correctly
- [ ] Add or update tests, if possible
- [x] All tests passing
- [x] Update the README, if necessary
- [ ] New contributor? added myself via `npm run contributor:add`

Closes #70 