### PR TITLE
Remove @types/vscode as dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -299,12 +299,6 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "@types/vscode": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.37.0.tgz",
-      "integrity": "sha512-PRfeuqYuzk3vjf+puzxltIUWC+AhEGYpFX29/37w30DQSQnpf5AgMVf7GDBAdmTbWTBou+EMFz/Ne6XCM/KxzQ==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -435,7 +435,6 @@
     "@types/micromatch": "^3.1.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.2",
-    "@types/vscode": "^1.37.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "all-contributors-cli": "^6.9.3",


### PR DESCRIPTION
### Changelog

Got an issue with conflict compilation because
there are two type definitions available
from @types/vscode and vscode

### Checklist

- [x] Code compiles correctly
- [ ] Add or update tests, if possible
- [x] All tests passing
- [ ] Update the README, if necessary
- [ ] New contributor? added myself via `npm run contributor:add`
