### PR TITLE
Make the search query more flexible

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -119,6 +119,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kneirinck",
+      "name": "Klaas Neirinck",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/3418790?v=4",
+      "profile": "https://bitbucket.org/kneirinck/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ Thank you for these awesome contributors
     <td align="center"><a href="https://ozylog.com"><img src="https://avatars3.githubusercontent.com/u/534150?v=4" width="100px;" alt="Cahya Pribadi"/><br /><sub><b>Cahya Pribadi</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=ozylog" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/markokajzer"><img src="https://avatars3.githubusercontent.com/u/9379317?v=4" width="100px;" alt="Marko Kajzer"/><br /><sub><b>Marko Kajzer</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=markokajzer" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/akdir"><img src="https://avatars0.githubusercontent.com/u/19649463?v=4" width="100px;" alt="akdir"/><br /><sub><b>akdir</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=akdir" title="Code">💻</a></td>
+    <td align="center"><a href="https://bitbucket.org/kneirinck/"><img src="https://avatars0.githubusercontent.com/u/3418790?v=4" width="100px;" alt="Klaas Neirinck"/><br /><sub><b>Klaas Neirinck</b></sub></a><br /><a href="https://github.com/deerawan/vscode-dash/commits?author=kneirinck" title="Code">💻</a></td>
   </tr>
 </table>
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## License

--- a/package.json
+++ b/package.json
@@ -422,6 +422,11 @@
           "type": "string",
           "description": "Controls which search URI should be used to perform the search.",
           "default": null
+        },
+        "dash.searchQueryExcludeDocsets": {
+          "type": "boolean",
+          "description": "Controls whether docsets will be excluded in the search query.",
+          "default": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -417,6 +417,11 @@
           "type": "boolean",
           "description": "Controls whether Dash should search the keyword in exact docsets specified in docset setting.",
           "default": false
+        },
+        "dash.searchUri": {
+          "type": "string",
+          "description": "Controls which search URI should be used to perform the search.",
+          "default": null
         }
       }
     }

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -29,14 +29,15 @@ export class Dash {
       .map(docset => `${this.option.exactDocset ? 'exact:' : ''}${docset}`)
       .join(',');
     const encodedQuery = encodeURIComponent(query);
-    return `${this.URIHandler} "dash-plugin://query=${encodedQuery}${
       keys ? `&keys=${keys}` : ``
+    return `${this.URIHandler} "${this.option.searchUri ? this.option.searchUri : 'dash-plugin://query='}${encodedQuery}${
     }"`;
   }
 }
 
 export interface DashOption {
   exactDocset: boolean;
+  searchUri?: string;
 }
 
 interface OSOptions {

--- a/src/dash.ts
+++ b/src/dash.ts
@@ -29,8 +29,8 @@ export class Dash {
       .map(docset => `${this.option.exactDocset ? 'exact:' : ''}${docset}`)
       .join(',');
     const encodedQuery = encodeURIComponent(query);
-      keys ? `&keys=${keys}` : ``
     return `${this.URIHandler} "${this.option.searchUri ? this.option.searchUri : 'dash-plugin://query='}${encodedQuery}${
+      keys && !this.option.searchQueryExcludeDocsets ? `&keys=${keys}` : ``
     }"`;
   }
 }
@@ -38,6 +38,7 @@ export class Dash {
 export interface DashOption {
   exactDocset: boolean;
   searchUri?: string;
+  searchQueryExcludeDocsets?: boolean;
 }
 
 interface OSOptions {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,9 +181,13 @@ function getDashOption(): DashOption {
   const searchUri = workspace
     .getConfiguration('dash')
     .get('searchUri') as string;
+  const searchQueryExcludeDocsets = workspace
+    .getConfiguration('dash')
+    .get('searchQueryExcludeDocsets') as boolean;
 
   return {
     exactDocset,
     searchUri,
+    searchQueryExcludeDocsets,
   };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,8 +178,12 @@ function getDashOption(): DashOption {
   const exactDocset = workspace
     .getConfiguration('dash')
     .get('exactDocset') as boolean;
+  const searchUri = workspace
+    .getConfiguration('dash')
+    .get('searchUri') as string;
 
   return {
     exactDocset,
+    searchUri,
   };
 }

--- a/test/dash.test.ts
+++ b/test/dash.test.ts
@@ -72,4 +72,17 @@ suite('Dash Tests', () => {
 
     assert.equal(uri, 'open -g "https://github.com/search?q=size&keys=exact:css,exact:less"');
   });
+
+  test('Exclude docsets in search query', () => {
+    const dashOptionExcludeDocsets: DashOption = {
+      ...dashOptionExactDocsetEnabled,
+      searchUri: "https://github.com/search?q=",
+      searchQueryExcludeDocsets: true,
+    };
+
+    const dash = new Dash('darwin', dashOptionExcludeDocsets);
+    const uri = dash.getCommand('size', ['css', 'less']);
+
+    assert.equal(uri, 'open -g "https://github.com/search?q=size"');
+  });
 });

--- a/test/dash.test.ts
+++ b/test/dash.test.ts
@@ -63,4 +63,13 @@ suite('Dash Tests', () => {
 
     assert.equal(uri, 'open -g "dash-plugin://query=size&keys=css,less"');
   });
+
+  test('Override search URI', () => {
+    const dashOptionSearchUriSet: DashOption = { ...dashOptionExactDocsetEnabled, searchUri: "https://github.com/search?q=" };
+
+    const dash = new Dash('darwin', dashOptionSearchUriSet);
+    const uri = dash.getCommand('size', ['css', 'less']);
+
+    assert.equal(uri, 'open -g "https://github.com/search?q=size&keys=exact:css,exact:less"');
+  });
 });


### PR DESCRIPTION
### Changelog

Make it possible to configure the search URI and also exclude the docsets from the search query.
As such you can use this extension with https://github.com/egoist/devdocs-desktop on macOS by setting the URI to `devdocs://search/` and excluding the docsets.

### Checklist

- [x] Code compiles correctly
- [x] Add or update tests, if possible
- [x] All tests passing
- [ ] Update the README, if necessary
- [x] New contributor? added myself via `npm run contributor:add`